### PR TITLE
Make pg_notify trigger optional. (It makes a big difference.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,59 +2,17 @@
 
 Quick 'n' dirty test to see how Ecto + Postgres behave in specific microbenchmarks.
 
-## Test Methodology
-
-
-### For Ecto + Benchee
-
-```
-$ mix ecto.drop && mix ecto.create && mix ecto.migrate && mix run bench/create_item_fast.exs 
-Deleting all existing items ...
-Starting test ...
-Operating System: macOS
-CPU Information: Intel(R) Core(TM) i7-4980HQ CPU @ 2.80GHz
-Number of Available Cores: 8
-Available memory: 16 GB
-Elixir 1.9.1
-Erlang 22.0.7
-
-Benchmark suite executing with the following configuration:
-warmup: 2 s
-time: 10 s
-memory time: 0 ns
-parallel: 5
-inputs: none specified
-Estimated total run time: 12 s
-
-Benchmarking create item...
-
-Name                  ips        average  deviation         median         99th %
-create item        1.36 K      734.57 μs   ±702.99%         422 μs         635 μs
-```
-
-### For pgbench
-
-```
-$ mix ecto.drop && mix ecto.create && mix ecto.migrate && pgbench -f pgbench/create_item_fast.sql -n -c 10 -j 5 -T 10 pghr
-transaction type: pgbench/create_item_fast.sql
-scaling factor: 1
-query mode: simple
-number of clients: 10
-number of threads: 5
-duration: 10 s
-number of transactions actually processed: 206051
-latency average = 0.487 ms
-tps = 20515.651758 (including connections establishing)
-tps = 20523.650252 (excluding connections establishing)
-```
-
 ## Results
 
-The benchmark results described below were run on my 2015-era MacBook Pro. Tests were always run for 10 seconds with a 2-second warm-up. Varying levels of parallelism were used and noted in the test results.
+The benchmark results described below were run on my 2015-era MacBook Pro. Tests were always run for 30 seconds with a 2-second warm-up. Varying levels of parallelism were used and noted in the test results.
 
-~~I want to emphasize a performance correlation I've observed on update with size of the existing table, so I'm removing previous results. All results here are run with 10 parallel clients and a pool size of 40, which had been shown in previous tests to be among the "best" configurations.~~
+Update (27 September 2019): In this round of benchmarks, I'm consistently using the following parameters across all experiments:
 
-With `Enum.random/1` removed from the test, this claim is disproven. Still seeing a constant difference between `pgbench` and Ecto, but there are leads to follow.
+* 30-second duration
+* 40 pgbench threads / 40 Elixir processes
+* 40 Postgres connections
+
+I've discarded previous results and am running with these settings across the board.
 
 ### Create Item Benchmark
 
@@ -67,18 +25,14 @@ $ mix ecto.drop && mix ecto.create && mix ecto.migrate && mix run bench/create_i
 Pgbench:
 
 ```
-$ mix ecto.drop && mix ecto.create && mix ecto.migrate && pgbench -f pgbench/create_item_fast.sql -n -c 40 -j 10 -T 10 pghr
+$ mix ecto.drop && mix ecto.create && mix ecto.migrate && pgbench -f pgbench/create_item_fast.sql -n -c 40 -j 40 -T 30 pghr
 ```
 
-   ips | duration | Comments
-------:|---------:|:---
- 14864 |       10 | Ecto
- 14794 |       30 |
- 14521 |      100 |
- 28058 |       10 | pgbench
- 27231 |       30 |
- 26002 |      100 |
- 
+notify? | Ecto ips | pg_bench ips | Ecto % of pgbench | Comments
+--------|---------:|-------------:|------------------:|-----
+      N |    21138 |        24168 |               87% | Baseline (PR #18)
+      Y |     9445 |         9464 |              100% |   
+
 ### Update Item Benchmark (Using Raw SQL Update)
 
 Ecto:
@@ -90,31 +44,10 @@ $ mix ecto.drop && mix ecto.create && mix ecto.migrate && mix run bench/update_i
 Pgbench:
 
 ```
-$ mix ecto.drop && mix ecto.create && mix ecto.migrate && pgbench -f pgbench/update_item_fast.sql -n -c 40 -j 10 -T 30 pghr
+$ mix ecto.drop && mix ecto.create && mix ecto.migrate && mix run pgbench/seed_items.exs && pgbench -f pgbench/update_item_fast.sql -n -c 40 -j 40 -T 30 pghr
 ```
 
-   ips | seed size | duration | clients | Comments
-------:|----------:|---------:|--------:|:---
- 23482 |       500 |       30 |      10 | Ecto
- 22443 |      5000 |       30 |      10 |
- 23407 |      5000 |       30 |      20 |
- 26075 |      5000 |       30 |      30 |
- 29035 |      5000 |       30 |      40 |
- 30618 |      5000 |       30 |      50 | (pool size: 50)
- 31043 |      5000 |       30 |      60 | (pool size: 60)
- 31408 |      5000 |       30 |      70 | (pool size: 70)
- 32745 |      5000 |       30 |      80 | (pool size: 80)
- 32175 |      5000 |       30 |      90 | (pool size: 90)
- 30147 |      5000 |       30 |     100 | (pool size: 100)
- 22168 |     50000 |       30 |      10 |
- 21188 |    500000 |       30 |      10 |
- 46024 |       500 |       30 |      10 | pgbench
- 47234 |      5000 |       30 |      10 |
- 47294 |      5000 |       30 |      20 |
- 48151 |      5000 |       30 |      30 |
- 47264 |      5000 |       30 |      40 |
- 47304 |     50000 |       30 |      10 |
- 46712 |    500000 |       30 |      10 |
-     – |         – |        – |       – | –
- 45590 |      5000 |       30 |      40 | pgbench (add notification trigger PR #16)
- 10698 |      5000 |       30 |      40 | Ecto
+notify? | Ecto ips | pg_bench ips | Ecto % of pgbench | Comments
+--------|---------:|-------------:|------------------:|-----
+      N |    28579 |        28175 |              101% | Baseline (PR #18)
+      Y |    10142 |         9501 |              107% |   

--- a/bench/create_item_fast.exs
+++ b/bench/create_item_fast.exs
@@ -18,8 +18,8 @@ ParallelBench.run(
         mumble3: "Moar Mumble #{random}"
       })
   end,
-  parallel: 10,
-  duration: 10
+  parallel: 40,
+  duration: 30
 )
 
 IO.inspect(SQL.query!(Repo, "SELECT count(*) FROM items;"),

--- a/bench/update_item_sql.exs
+++ b/bench/update_item_sql.exs
@@ -55,6 +55,6 @@ ParallelBench.run(
         cache_statement: "update_item_mumble"
       )
   end,
-  parallel: 10,
+  parallel: 40,
   duration: 30
 )

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,7 @@ config :logger, level: :warn
 
 config :pghr,
   ecto_repos: [Pghr.Repo],
+  notif_trigger?: true,
   namespce: Pghr
 
 config :pghr, Pghr.Repo,

--- a/priv/repo/migrations/20190925183004_add_notif_trigger.exs
+++ b/priv/repo/migrations/20190925183004_add_notif_trigger.exs
@@ -2,24 +2,28 @@ defmodule Pghr.Migrations.AddNotifTrigger do
   use Ecto.Migration
 
   def up do
-    execute """
-    CREATE OR REPLACE FUNCTION send_pool_change_notice()
-      RETURNS trigger
-      AS $function$
-      BEGIN
-        PERFORM pg_notify('change', 'pools|' || text(NEW.mumble1) || '|' || text(NEW.id));
-        RETURN NEW;
-      END
-      $function$
-      LANGUAGE plpgsql;
-    """
+    if Application.get_env(:pghr, :notif_trigger?, false) do
+      IO.puts("Adding notif trigger")
 
-    execute """
-    CREATE TRIGGER pool_change_trigger
-    AFTER INSERT OR UPDATE
-    ON items
-    FOR EACH ROW
-    EXECUTE PROCEDURE send_pool_change_notice();
-    """
+      execute("""
+      CREATE OR REPLACE FUNCTION send_pool_change_notice()
+        RETURNS trigger
+        AS $function$
+        BEGIN
+          PERFORM pg_notify('change', 'pools|' || text(NEW.mumble1) || '|' || text(NEW.id));
+          RETURN NEW;
+        END
+        $function$
+        LANGUAGE plpgsql;
+      """)
+
+      execute("""
+      CREATE TRIGGER pool_change_trigger
+      AFTER INSERT OR UPDATE
+      ON items
+      FOR EACH ROW
+      EXECUTE PROCEDURE send_pool_change_notice();
+      """)
+    end
   end
 end


### PR DESCRIPTION
Re-run tests being consistent about using 40 threads/OTP processes, 40 PG clients, 30 seconds duration.

Ecto is now outperforming pgbench in some benchmarks.