### PR TITLE
Remove random number generation from create and update benchmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ notify? | Ecto ips | pg_bench ips | Ecto % of pgbench | Comments
  Y      |     8885 |         9464 |               94% |   
  N      |    21188 |        24168 |               88% | 1000 iterations per checkout (PR #20)
  Y      |     9141 |         9464 |               97% |   
+ N      |    21689 |        24168 |               88% | Remove random number (PR #21)
+ Y      |     9266 |         9464 |               98% |   
 
 ### Update Item Benchmark (Using Raw SQL Update)
 
@@ -59,3 +61,5 @@ notify? | Ecto ips | pg_bench ips | Ecto % of pgbench | Comments
  Y      |     9935 |         9501 |              105% |   
  N      |    29413 |        28175 |              104% | 1000 iterations per checkout (PR #20)
  Y      |     9959 |         9501 |              105% |   
+ N      |    29356 |        28175 |              104% | Remove random number (PR #21)
+ Y      |    10057 |         9501 |              106% |   

--- a/bench/create_item_fast.exs
+++ b/bench/create_item_fast.exs
@@ -9,7 +9,7 @@ Repo.delete_all(Item)
 
 ParallelBench.run(
   fn ->
-    random = :rand.uniform(100_000_000_000_000)
+    random = :erlang.unique_integer([:positive])
 
     {:ok, _} =
       Repo.insert(%Item{

--- a/bench/update_item_sql.exs
+++ b/bench/update_item_sql.exs
@@ -40,8 +40,11 @@ IO.puts("Starting test ...")
 
 ParallelBench.run(
   fn ->
-    random_item_id = :rand.uniform(seed_count - 1) + first_item_id
-    random_mumble = Map.get(new_mumbles, :rand.uniform(mumble_count))
+    random_item_id =
+      first_item_id + Integer.mod(:erlang.unique_integer([:positive]), seed_count - 1)
+
+    random_mumble =
+      Map.get(new_mumbles, 1 + Integer.mod(:erlang.unique_integer([:positive]), mumble_count - 1))
 
     {:ok, %{num_rows: 1}} =
       SQL.query(


### PR DESCRIPTION
Adapted from Ben's #17. Very subtle perf changes.